### PR TITLE
Changed to exclusively use absolute file paths

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,9 @@
 
 # --- [change these] ---
 
+# local workspace
+LOCAL_WS="/home/$USER/dev_ws"
+
 # remote workspace
 REMOTE_WS="csrobot@10.0.9.2:/home/csrobot/remote_ws"
 # REMOTE_WS="/home/$USER/remote_ws"
@@ -11,7 +14,9 @@ PACKAGE_NAME="scooter"
 
 # ----------------------
 
-DESTINATION="${REMOTE_WS}/src/$PACKAGE_NAME"
+SOURCE="${LOCAL_WS}/src/${PACKAGE_NAME}"
+DESTINATION="${REMOTE_WS}/src"
+
 SKIP_CONFIRM=0
 
 # parse options
@@ -26,7 +31,7 @@ done
 # confirmation prompt
 if [ $SKIP_CONFIRM == 0 ]; then
     # confirm
-    read -p "This will overwrite $DESTINATION, are you sure? (y/n) " -n 1 -r
+    read -p "This will overwrite ${DESTINATION}/${PACKAGE_NAME}, are you sure? (y/n) " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]
     then
@@ -35,4 +40,4 @@ if [ $SKIP_CONFIRM == 0 ]; then
 fi
 
 # rsync
-rsync -avz ../$PACKAGE_NAME $DESTINATION
+rsync -avz $SOURCE $DESTINATION


### PR DESCRIPTION
The deploy script now exclusively uses absolute file paths to avoid issues if you run it from a different directory